### PR TITLE
Added offMonth visibility settings to hide days out of the current month

### DIFF
--- a/src/classes.ts
+++ b/src/classes.ts
@@ -42,6 +42,7 @@ const classes = {
 	dayBtnPrev: 'vanilla-calendar-day__btn_prev',
 	dayBtnNext: 'vanilla-calendar-day__btn_next',
 	dayBtnToday: 'vanilla-calendar-day__btn_today',
+	dayBtnOffMonth: 'vanilla-calendar-day__btn_offMonth',
 	dayBtnSelected: 'vanilla-calendar-day__btn_selected',
 	dayBtnDisabled: 'vanilla-calendar-day__btn_disabled',
 	dayBtnIntermediate: 'vanilla-calendar-day__btn_intermediate',

--- a/src/scripts/methods/createDays.ts
+++ b/src/scripts/methods/createDays.ts
@@ -142,7 +142,10 @@ const createDays = (self: IVanillaCalendar) => {
 			const prevMonthID = dayIDCurrent.getUTCMonth() - 1;
 			const dayID = new Date(Date.UTC(self.selectedYear, prevMonthID, day)).getUTCDay();
 
-			createDay(String(day), dayID, date, false, self.CSSClasses.dayBtnPrev);
+			if (!self.settings.visibility.offMonth)
+				createDay(String(i), dayID, date, false, self.CSSClasses.dayBtnNext);
+			else
+				createDay(String(i), dayID, date, false, self.CSSClasses.dayBtnOffMonth);
 		}
 	};
 
@@ -180,7 +183,10 @@ const createDays = (self: IVanillaCalendar) => {
 			const nextMonthID = dayIDCurrent.getUTCMonth() + 1;
 			const dayID = new Date(Date.UTC(self.selectedYear, nextMonthID, i)).getUTCDay();
 
-			createDay(String(i), dayID, date, false, self.CSSClasses.dayBtnNext);
+			if (!self.settings.visibility.offMonth)
+				createDay(String(i), dayID, date, false, self.CSSClasses.dayBtnNext);
+			else
+				createDay(String(i), dayID, date, false, self.CSSClasses.dayBtnOffMonth);
 		}
 	};
 

--- a/src/scripts/methods/createDays.ts
+++ b/src/scripts/methods/createDays.ts
@@ -143,9 +143,9 @@ const createDays = (self: IVanillaCalendar) => {
 			const dayID = new Date(Date.UTC(self.selectedYear, prevMonthID, day)).getUTCDay();
 
 			if (!self.settings.visibility.offMonth)
-				createDay(String(i), dayID, date, false, self.CSSClasses.dayBtnNext);
+				createDay(String(day), dayID, date, false, self.CSSClasses.dayBtnNext);
 			else
-				createDay(String(i), dayID, date, false, self.CSSClasses.dayBtnOffMonth);
+				createDay(String(day), dayID, date, false, self.CSSClasses.dayBtnOffMonth);
 		}
 	};
 

--- a/src/scripts/vanilla-calendar.ts
+++ b/src/scripts/vanilla-calendar.ts
@@ -80,6 +80,7 @@ export default class VanillaCalendar<T extends (HTMLElement | string), R extends
 				weekend: option?.settings?.visibility?.weekend ?? true,
 				today: option?.settings?.visibility?.today ?? true,
 				disabled: option?.settings?.visibility?.disabled ?? false,
+				offMonth: option?.settings?.visibility?.offMonth ?? false,
 			},
 		};
 		this.locale = {

--- a/src/styles/vanilla-calendar.scss
+++ b/src/styles/vanilla-calendar.scss
@@ -516,6 +516,10 @@
 				}
 			}
 
+			&_offMonth {
+				display: none;
+			}
+
 			&_disabled {
 				pointer-events: none;
 				background-color: white;

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface IVisibility {
 	weekend: boolean;
 	today: boolean;
 	disabled: boolean;
+	offMonth: boolean;
 }
 
 export interface ISettings {
@@ -123,6 +124,7 @@ export interface ICSSClasses {
 	dayBtnNext: string;
 	dayBtnSelected: string;
 	dayBtnIntermediate: string;
+	dayBtnOffMonth: string;
 	dayBtnDisabled: string;
 	dayBtnToday: string;
 	dayBtnWeekend: string;


### PR DESCRIPTION
Pretty straighforward to what the title says, this options hides the days that are out of the current month displayed.

That are several ways to implement this feature, like changing createDay() or setDayModifier() functions. This PR changes prevMonth() and nexMonth() with a offMonth check. Although all day generation code is executed, this way makes the code cleaner and consistency with the option _visibility_ (the days are there, but hidden).

Edit: Forgot to say that the motivation for this PR is that when using multiple instances of the calendar (within a loop) and popups, the same popup on a date in the beginning or end of the month give the illusion of two different popups

![image](https://user-images.githubusercontent.com/30537409/207478456-bd5df675-97ff-4605-919a-a0c355634402.png) vs ![image](https://user-images.githubusercontent.com/30537409/207478507-588cd194-7309-4b21-ac41-05840e24e2eb.png)
