### PR TITLE
Add getDays

### DIFF
--- a/package/src/scripts/main.ts
+++ b/package/src/scripts/main.ts
@@ -108,6 +108,7 @@ export default class VanillaCalendar<T extends (HTMLElement | string), R extends
 			clickArrow: option?.actions?.clickArrow ?? null,
 			changeTime: option?.actions?.changeTime ?? null,
 			changeToInput: option?.actions?.changeToInput ?? null,
+			getDays: option?.actions?.getDays ?? null,
 		};
 		this.popups = option?.popups ?? null;
 		this.CSSClasses = (() => {

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -148,6 +148,7 @@ const createDays = (self: IVanillaCalendar) => {
 			}
 
 			daysEls[index].append(dayEl);
+			if (self.actions.getDays) self.actions.getDays(Number(dayText), date, dayEl, dayBtnEl);
 		};
 
 		const prevMonth = () => {

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -74,6 +74,7 @@ export interface IActions {
 	clickArrow: ((e: MouseEvent, year: number, month: number) => void) | null;
 	changeTime: ((e: Event, time: string, hours: string, minutes: string, keeping: string) => void) | null;
 	changeToInput: ((e: Event, HTMLInputElement: HTMLElement, dates?: string[], time?: string, hours?: string, minutes?: string, keeping?: string) => void) | null;
+	getDays: ((day: number, date: string, HTMLElement: HTMLElement, HTMLButtonElement: HTMLButtonElement) => void) | null;
 }
 
 export type IPopups = {


### PR DESCRIPTION
Added a new `actions` that allows you to get the necessary information and html element of each day during calendar initialization.