### PR TITLE
Add a calendar destroy method

### DIFF
--- a/package/src/index.d.ts
+++ b/package/src/index.d.ts
@@ -44,6 +44,8 @@ declare class VanillaCalendar<T extends (HTMLElement | string), R extends Partia
 
 	init: () => void;
 
+	destroy: () => void;
+
 	input: boolean;
 
 	type: 'default' | 'multiple' | 'month' | 'year';

--- a/package/src/scripts/methods/destroyCalendar.ts
+++ b/package/src/scripts/methods/destroyCalendar.ts
@@ -1,0 +1,14 @@
+import { IVanillaCalendar } from '../../types';
+
+const destroyCalendar = (self: IVanillaCalendar) => {
+	if (!self.HTMLOriginalElement) return;
+	if (self.input) {
+		self.HTMLInputElement?.replaceWith(self.HTMLOriginalElement);
+		self.HTMLElement?.parentNode?.removeChild(self.HTMLElement);
+	} else {
+		self.HTMLElement?.replaceWith(self.HTMLOriginalElement);
+	}
+	self.HTMLElement = self.HTMLOriginalElement;
+};
+
+export default destroyCalendar;

--- a/package/src/scripts/methods/initCalendar.ts
+++ b/package/src/scripts/methods/initCalendar.ts
@@ -5,6 +5,7 @@ import clickCalendar from './clickCalendar';
 
 const initCalendar = (self: IVanillaCalendar) => {
 	if (!self.HTMLElement) return;
+	self.HTMLOriginalElement = self.HTMLElement.cloneNode(true) as HTMLElement;
 	if (self.input) {
 		handlerInput(self);
 	} else {

--- a/package/src/scripts/vanilla-calendar.ts
+++ b/package/src/scripts/vanilla-calendar.ts
@@ -17,6 +17,7 @@ import DOMMultiple from './templates/DOMMultiple';
 import DOMMonth from './templates/DOMMonth';
 import DOMYear from './templates/DOMYear';
 import classes from '../classes';
+import destroyCalendar from './methods/destroyCalendar';
 
 export default class VanillaCalendar<T extends (HTMLElement | string), R extends IOptions> {
 	HTMLElement: HTMLElement | null;
@@ -139,4 +140,6 @@ export default class VanillaCalendar<T extends (HTMLElement | string), R extends
 	update = () => updateCalendar(this);
 
 	init = () => initCalendar(this);
+
+	destroy = () => destroyCalendar(this);
 }

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -201,6 +201,7 @@ export interface IVariables extends IOptions {
 }
 
 export interface IVanillaCalendar extends IVariables {
+	HTMLOriginalElement?: HTMLElement;
 	HTMLInputElement?: HTMLInputElement;
 	rangeMin?: FormatDateString;
 	rangeMax?: FormatDateString;


### PR DESCRIPTION
Add `HTMLOriginalElement` - the original html element, without modifications.
Add `destroy()` - Destroy the calendar instance and its event listeners. #141 